### PR TITLE
don't throw exception on a valid composer.json

### DIFF
--- a/lint/linter/ComposerLinter.php
+++ b/lint/linter/ComposerLinter.php
@@ -184,15 +184,19 @@ class ComposerLinter extends ArcanistExternalLinter
             return [$message];
         }
 
+        if ($err === 0) { // successful validation
+            return [];
+        }
+
+        if (!$stderr) { // error code, but no output to parse
+            return false;
+        }
+
         $this->parsedFiles[] = $jsonPath;
 
         $jsonContents    = '';
         $requireContents = '';
         $requireLineNum  = 0;
-
-        if (!$stderr) {
-            return false;
-        }
 
         $lines = phutil_split_lines($stderr, $retain_endings = false);
 


### PR DESCRIPTION
If composer.json was valid, the linter was throwing an error:

```
Some linters failed:
    - Exception: Linter failed to parse output!

      STDOUT
      ./composer.json is valid


      STDERR

(Run with `--trace` for a full exception trace.)
```

Now we're returning an empty array (no lint messages) in this event. We're still returning false, which throws an exception, if `composer validate` fails but there's no output to parse. This is consistent with the docs in ArcanistExternalLinter:
>    * @return list<ArcanistLintMessage>|false  List of lint messages, or false
>    *                                          to indicate parser failure.

From: https://github.com/phacility/arcanist/blob/master/src/lint/linter/ArcanistExternalLinter.php#L218
